### PR TITLE
cellranger: update  pyopenssl dependency to version 18

### DIFF
--- a/recipes/cellranger/3.0.2/meta.yaml
+++ b/recipes/cellranger/3.0.2/meta.yaml
@@ -49,7 +49,7 @@ requirements:
     - et_xmlfile 1.0.1
     - tsne >=0.1.5
     - jdcal 1.4
-    - pyopenssl 17.0.0
+    - pyopenssl 18.0.0
     - jinja2 2.10
     - packaging 16.8
     - snappy 1.1.7


### PR DESCRIPTION
pyopenssl  17.0.0 is not available through conda and 
